### PR TITLE
Fix wm detection when using workaround for electron apps

### DIFF
--- a/fetch_cord/testing.py
+++ b/fetch_cord/testing.py
@@ -115,11 +115,11 @@ def iMate():
 	desktopid = "mate"
 def iUnity():
 	#this is to check wether the user is actually using unity or using unity as an xdg value to fix issues with electron apps
-	if wm.lower() == "compiz":
+	if wmid.lower() == "compiz":
 		global desktopid
 		desktopid = "unity"
 	else:
-		desktopid = wm
+		desktopid = wmid
 # cpuids
 def Amdcpu():
         global cpuid, cpuappid


### PR DESCRIPTION
fixes wm/DE detection when user uses the "Unity" workaround to make systray/appindicators for electron applications work