### PR TITLE
Make RPC exceptions non-fatal + proper sysd unit

### DIFF
--- a/discord
+++ b/discord
@@ -1,7 +1,0 @@
-#!/bin/bash
-/opt/Discord/Discord &
-# give discord time to start
-sleep 30
-echo "starting fetchcord"
-fetchcord
-

--- a/fetch_cord/run_rpc.py
+++ b/fetch_cord/run_rpc.py
@@ -1,5 +1,5 @@
 # Import cool new rpc module that gives us more control and gets rid of headaches :)
-from pypresence import Presence
+from pypresence import Presence, exceptions
 import time
 import sys
 import os
@@ -48,6 +48,33 @@ if sysosid.lower() != "macos" and os.name != "nt":
 print("RPC connection successful.")
 
 
+def rpc_tryconnect():
+    while True:
+        try:
+            RPC.connect()
+            break
+        except ConnectionRefusedError:
+            print("RPC connection refused (is Discord open?); trying again in 30 seconds")
+            time.sleep(30)
+
+
+def rpc_tryclear():
+    try:
+        RPC.clear(pid=os.getpid())
+    except exceptions.InvalidID:
+        pass
+
+
+def rpc_tryupdate(state, details, large_image, large_text, small_image, small_text, start):
+    try:
+        RPC.update(state=state, details=details, large_image=large_image,
+                    large_text=large_text, small_image=small_image, small_text=small_text,
+                    start=start)
+    # ConnectionResetError is here to avoid crashing if Discord is still just starting
+    except (ConnectionResetError, exceptions.InvalidID):
+        pass
+
+
 def runmac():
     global RPC
     from fetch_cord.testing import devicetype, product, bigicon, ver
@@ -63,8 +90,8 @@ def runmac():
     time.sleep(5)
     while True:
         RPC = Presence(client_id)
-        RPC.connect()
-        RPC.update(state=packagesline[0],  # uptadte state as packages
+        rpc_tryconnect()
+        rpc_tryupdate(state=packagesline[0],  # update state as packages
                    details=kernelline[0],  # update details as kernel
                    large_image=bigicon,  # set icon
                    large_text=sysosline[0],  # set large icon text
@@ -88,8 +115,8 @@ def cycle0():
         print("cycle 0")
     client_id = appid
     RPC = Presence(client_id)
-    RPC.connect()
-    RPC.update(state=packagesline[0],
+    rpc_tryconnect()
+    rpc_tryupdate(state=packagesline[0],
                details=kernelline[0],
                large_image="big",
                large_text=sysosline[0],
@@ -116,8 +143,8 @@ def cycle1():
         print("cycle 1")
     client_id = cpuappid
     RPC = Presence(client_id)
-    RPC.connect()
-    RPC.update(state=cpuinfo,
+    rpc_tryconnect()
+    rpc_tryupdate(state=cpuinfo,
                details=gpuinfo,
                large_image="big",
                large_text=cpuinfo,
@@ -143,8 +170,8 @@ def cycle2():
         print("cycle 2")
     client_id = termappid
     RPC = Presence(client_id)
-    RPC.connect()
-    RPC.update(state=shell_line[0],
+    rpc_tryconnect()
+    rpc_tryupdate(state=shell_line[0],
                details=termfontline,
                large_image="big",
                large_text=termline[0],
@@ -169,8 +196,8 @@ def cycle3():
             print("cycle 3")
         client_id = hostappid
         RPC = Presence(client_id)
-        RPC.connect()
-        RPC.update(state=resline,
+        rpc_tryconnect()
+        rpc_tryupdate(state=resline,
                 details=hostline[0],
                 large_image="big",
                 large_text=hostline[0],
@@ -196,8 +223,8 @@ def w_cycle0():
         print("cycle 0")
     client_id = appid
     RPC = Presence(client_id)
-    RPC.connect()
-    RPC.update(state=sysosline[0],
+    rpc_tryconnect()
+    rpc_tryupdate(state=sysosline[0],
                details=memline[0],
                large_image="big",
                large_text=sysosline[0],
@@ -220,8 +247,8 @@ def w_cycle1():
         print("cycle 1")
     client_id = cpuappid
     RPC = Presence(client_id)
-    RPC.connect()
-    RPC.update(state=cpuinfo,
+    rpc_tryconnect()
+    rpc_tryupdate(state=cpuinfo,
                details=gpuinfo,
                large_image="big",
                large_text=cpuinfo,
@@ -244,16 +271,16 @@ def loonix():
         while True:
             if not args.nodistro:
                 cycle0()
-                RPC.clear(pid=os.getpid())
+                rpc_tryclear()
             if not args.nohardware:
                 cycle1()
-                RPC.clear(pid=os.getpid())
+                rpc_tryclear()
             if not args.noshell:
                 cycle2()
-                RPC.clear(pid=os.getpid())
+                rpc_tryclear()
             if not args.nohost:
                 cycle3()
-                RPC.clear(pid=os.getpid())
+                rpc_tryclear()
     except KeyboardInterrupt:
         print("Closing connection.")
         sys.exit(0)
@@ -264,10 +291,10 @@ def wandowz():
         while True:
             if not args.nodistro:
                 w_cycle0()
-                RPC.clear(pid=os.getpid())
+                rpc_tryclear()
             if not args.nohardware:
                 w_cycle1()
-                RPC.clear(pid=os.getpid())
+                rpc_tryclear()
     except KeyboardInterrupt:
         print("Closing connection.")
         sys.exit(0)

--- a/readme.md
+++ b/readme.md
@@ -76,13 +76,13 @@ NOTE: you need neofetch to be also installed for this to work.
 
 If you want to remove FetchCord you can run `pip3 uninstall fetchcord`
 
-You can copy the discord script to somewhere in PATH to have fetchcord run upon opening discord, making sure the discord script is executable. `sudo chmod +x /path/to/discord/script`
-
 ### Run
 
-Once installed, simply run `fetchcord`.
+Once installed, simply run `fetchcord`. The program is also daemonizable meaning you can start it on boot using any method you prefer.
 
 If that does not work,add /home/$USER/.local/bin/ to your path, or just run `python3 -m fetchcord`.
+
+Optionally for `systemd` users there is a user-side `fetchcord.service` in this repo that can be installed to `~/.local/share/systemd/user/`, started and enabled on boot using `systemctl --user enable --now fetchcord`.
 
 #### Arguments
 --nodistro, Don't show distro info.

--- a/systemd/fetchcord.service
+++ b/systemd/fetchcord.service
@@ -1,9 +1,20 @@
+# Please use 'systemctl --user edit fetchcord' to change 'ExecStart' when adding arguments!
+# The following is a simple example of the override:
+
+# [Service]
+# ExecStart=
+# ExecStart=-%h/.local/bin/fetchcord --nohost --time 15 --terminal 'gnome-terminal' --termfont 'Terminus Medium'
+
 [Unit]
-Description=System info Discord Rich Presence Daemon
+Description=Display OS info as Discord Rich Presence
+Documentation=https://github.com/MrPotatoBobx/FetchCord
+After=network.target multi-user.target graphical-session.target
 
 [Service]
-Type=simple
-ExecStart=/usr/bin/python3 -u -m fetch_cord.run-rpc
+Environment=PYTHONUNBUFFERED=1
+ExecStart=-%h/.local/bin/fetchcord
+Restart=on-failure
+RestartSec=10
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
Now `fetchcord` is basically a daemon and doesn't crash whenever Discord isn't running, and instead waits 30 seconds to try connecting again to the RPC socket.

I've also written a proper user-side `systemd` unit file for the program and it seems to work rather well after testing :)