### PR TITLE
Fix the error preventing build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,42 +3,4 @@ from os.path import dirname, join
 import setuptools
 import fetch_cord.__init__ as __init__
 
-setuptools.setup(
-    name="FetchCord",
-    version=__init__.VERSION,
-    description="""
-        Grabs information about your Distro and displays it as Discord Rich Presence.
-    """,
-    long_description=open(join(dirname(__file__), "README.md")).read(),
-    long_description_content_type="text/markdown",
-    url="https://github.com/MrPotatoBobx/FetchCord",
-    author="MrPotatoBobx",
-    author_email="junkahole23@protonmail.com",
-    license="MIT",
-    package_data={
-        "fetch_cord": [
-            "config_schema.json",
-            "resources/default.conf",
-            "resources/fetch_cord.conf",
-            "resources/fetchcord_ids.json",
-            "computer/*.py",
-            "computer/*/*.py",
-        ]
-    },
-    packages=["fetch_cord"],
-    include_package_data=True,
-    install_requires=["pypresence", "psutil", "importlib-resources"],
-    extras_require={"gui": ["PyQt5"]},
-    keywords=["distro", "info", "discord", "fetch"],
-    classifiers=[
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Operating System :: OS Independent",
-    ],
-    python_requires=">=3.6",
-    entry_points={
-        "console_scripts": [
-            "fetchcord=fetch_cord.__main__:main",
-        ]
-    },
-)
+setuptools.setup(name="FetchCord",version=__init__.VERSION,description="""Grabs information about your Distro and displays it as Discord Rich Presence.""",long_description=open(join(dirname(__file__), "README.md")).read(),long_description_content_type="text/markdown",url="https://github.com/MrPotatoBobx/FetchCord",author="MrPotatoBobx",author_email="junkahole23@protonmail.com",license="MIT",package_data={"fetch_cord": ["config_schema.json","resources/default.conf","resources/fetch_cord.conf","resources/fetchcord_ids.json","computer/*.py","computer/*/*.py",]},packages=["fetch_cord"],include_package_data=True,install_requires=["pypresence", "psutil", "importlib-resources"],extras_require={"gui": ["PyQt5"]},keywords=["distro", "info", "discord", "fetch"],classifiers=["License :: OSI Approved :: MIT License","Programming Language :: Python :: 3","Operating System :: OS Independent",],python_requires=">=3.6",entry_points={"console_scripts": ["fetchcord=fetch_cord.__main__:main",]},)


### PR DESCRIPTION
Building from testing currently produces the `ValueError: Newlines are not allowed` exception when `setuptools.setup()` is called, presumably due to new functionality in `setuptools`. For building on the latest setuptools, all newlines (`\n`) in the code needs to go. I have already raised the issue in the support Discord Server.